### PR TITLE
Issue 4

### DIFF
--- a/R/read_shp.R
+++ b/R/read_shp.R
@@ -37,8 +37,15 @@ read_shp <- function (dsn = ".", layer = NULL, ..., verbose = getOption("verbose
     str_detect(dsn, regex("\\.zip$", ignore_case = TRUE))
   }
 
+  rmdir <- function (path) {
+    msg("deleting ", path)
+    base::unlink(path, recursive = TRUE)
+  }
+
   if (is_zipfile(dsn)) {
-    dsn <- unzip_only(dsn, pattern = layer, junkpaths = TRUE, verbose = verbose)
+    exdir <- unzip_only(dsn, pattern = layer, junkpaths = TRUE, verbose = verbose)
+    dsn <- exdir
+    on.exit(rmdir(exdir))
   }
 
   if (is.null(layer)) {

--- a/R/unzip_only.R
+++ b/R/unzip_only.R
@@ -20,8 +20,9 @@ unzip_only <- function (zip_file, pattern = NULL, junkpaths = FALSE, ..., verbos
     pattern <- ".*"
   }
 
-  exdir <- tempdir()
-  msg("tempdir() is: ", exdir)
+  exdir <- tempfile(pattern = basename(zip_file)) # NOT tempdir()
+  dir.create(exdir)
+  msg("exdir() is: ", exdir)
   msg("pattern is: ", pattern)
 
   # Get the names of all files in the ZIP archive. Don't unzip it just yet.


### PR DESCRIPTION
Fixes #4 by ensuring that the temporary `exdir`, into which a zipped shapefile is unzipped, is not reused — it's now both (a) uniquely named and (b) deleted after it's no longer used. 